### PR TITLE
Monkeypatch cmd to create setup.py subcmds.

### DIFF
--- a/gcd/nix.py
+++ b/gcd/nix.py
@@ -135,15 +135,9 @@ class Command:
             gen = fun()
             if gen is not None:  # Allow for sub cmds to be also top cmds.
                 next(gen)
-                try:
-                    next(gen)
-                except StopIteration:
-                    pass
+                next(gen, None)
         if '_gen' in self.args:  # Run second part of sub cmd.
-            try:
-                next(self.args._gen)
-            except StopIteration:
-                pass
+            next(self.args._gen, None)
 
 
 cmd = Command()

--- a/meka
+++ b/meka
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3.5
-
-from gcd.meka import cmd, pylint, pytest, meka
-
-cmd.sub(pylint())
-
-cmd.sub(pytest(cov_pkgs='gcd'))
-
-cmd.run(meka)

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,17 @@
 from setuptools import setup
 
+from gcd.meka import cmd, pylint, pytest, meka
+
+
+cmd.sub(pylint())
+
+cmd.sub(pytest(cov_pkgs='gcd'))
+
 setup(
     name='gcd',
     version='1.0',
     packages=['gcd'],
     package_data={'gcd': ['resources/*']},
-    scripts=['scripts/liftup', 'scripts/wacky']
+    scripts=['scripts/liftup', 'scripts/wacky'],
+    cmdclass=cmd.cmdclass
 )


### PR DESCRIPTION
Santi, this is a hack (but then, everything distutils/setuptools is an ugly over-engineered pile of hacks) to avoid having both setup.py and meka scripts, by just defining new setup.py subcommands using the same technique than we already use to define meka subcommands, and then registering them with distutils as cmdclasses. For example:

```python
from setuptools import setup
from gcd.meka import cmd

@cmd.sub
def something():
    "Something command"
    cmd.arg('-x', '--xxx', help='Whatever', nargs=1)
    cmd.arg('-yyy', help='Wherever')
    yield
    print(cmd.args)

@cmd.sub
def anything():
    "Anything command"
    cmd.arg('-x', '--xxx', help='Whatever', nargs=1)
    cmd.arg('-yyy', help='Wherever')
    yield
    print(cmd.args)

setup(
    name='nothing',
    version='1.0',
    cmdclass=cmd.cmdclass
)
```

The idea is to put the contents of meka into setup.py for every macross project and remove the meka files.